### PR TITLE
fix: remove "duplicated" board positions from Book.txt

### DIFF
--- a/Chess-Coding-Adventure/resources/Book.txt
+++ b/Chess-Coding-Adventure/resources/Book.txt
@@ -34563,8 +34563,6 @@ pos r1bqkb1r/pp2pppp/2n2n2/2p5/2Pp4/3P1NP1/PP2PPBP/RNBQ1RK1 b kq -
 e7e5 102
 pos r2qkbnr/ppp2ppp/2n1p3/3p1b2/3P4/5NP1/PPP1PPBP/RNBQK2R w KQkq -
 e1g1 24
-pos rnbqkb1r/pp3ppp/3p1n2/2pPp3/2P5/2N5/PP2PPPP/R1BQKBNR w KQkq e6
-e2e4 37
 pos rnbqkbnr/ppp2ppp/4p3/3p4/3P4/2P2N2/PP2PPPP/RNBQKB1R b KQkq -
 g8f6 137
 c7c5 67
@@ -44646,9 +44644,6 @@ pos r1bqkbnr/pp1p1ppp/2n5/2p1p3/4P3/5NP1/PPPP1P1P/RNBQKB1R w KQkq -
 f1g2 23
 pos r1bqkbnr/pp3ppp/2np4/2p1p3/4P3/5NP1/PPPP1PBP/RNBQK2R w KQkq -
 e1g1 27
-pos rnbqkbnr/pp3ppp/3p4/2pPp3/2P5/8/PP2PPPP/RNBQKBNR w KQkq e6
-b1c3 62
-e2e4 31
 pos rnbqkbnr/pp3ppp/4p3/3P4/3P4/8/PP3PPP/RNBQKBNR b KQkq -
 e6d5 47
 d8d5 20


### PR DESCRIPTION
**Motivation**
The Book.txt seems to be agnostic to en-passant square. For example, the second entry in the book is 
```
rnbqkbnr/pppppppp/8/8/3P4/8/PPP1PPPP/RNBQKBNR b KQkq -
```
And it technically it should be 
```
rnbqkbnr/pppppppp/8/8/3P4/8/PPP1PPPP/RNBQKBNR b KQkq d3
```
Because in openings, it's mostly impossible to take advantage of the en-passant square, it's a good trade-off to ignore it. That does make sense.

**The Issue**
There are two positions in the book that given the en-passant square is ignored are the same positions and duplicates of each other.

**PR Changes**
This PR updates Book.txt to remove those two "duplicate" positions . 

**Note**
I found that they are duplicates when creating a json version of the openings and using a modified zobrist hash that does not consider the en-passant square. AFAIK those are the only two "duplicate" entries

It might be the case that maybe the non en-passant position needs to be removed, but given that the 2nd, 4th and other  entries are not setting en-passant square in the fen notation, it seems to be a good option to remove the en-passant one .
